### PR TITLE
feat: extension install prompt

### DIFF
--- a/Sources/CardliftKit/CardliftKit.swift
+++ b/Sources/CardliftKit/CardliftKit.swift
@@ -1,4 +1,5 @@
 import Foundation
+import SwiftUI
 
 /// The main entry point for the CardliftKit SDK.
 /// All public APIs are exposed here, so consumers only import and interact with `CardliftKit`.
@@ -67,4 +68,19 @@ public enum CardliftKit {
     public static func computeCardMetaData(from formData: CardliftCardFormData) -> CardMetaData? {
         return CardMetaDataParser.computeCardMetaData(from: formData)
     }
+    
+    /**
+     Upsell View
+     Button with sheet to prompt user to install the extension
+     */
+    public static func UpSellView(url: URL, config: UpsellButtonConfig) -> some View {
+        return Upsell(
+            appStoreURL: url,
+            buttonConfig: UpsellButtonConfig(
+                text: config.text,
+                backgroundColor: config.backgroundColor,
+                foregroundColor: config.foregroundColor
+            ))
+    }
+
 }

--- a/Sources/CardliftKit/CardliftKit.swift
+++ b/Sources/CardliftKit/CardliftKit.swift
@@ -73,11 +73,10 @@ public enum CardliftKit {
      Upsell View
      Button with sheet to prompt user to install the extension
      */
-    public static func UpSellView(url: URL, config: UpsellButtonConfig) -> some View {
+    public static func InstallPrompt(slug: String, config: UpsellButtonConfig) -> some View {
         return Upsell(
-            appStoreURL: url,
+            slug: slug,
             buttonConfig: UpsellButtonConfig(
-                text: config.text,
                 backgroundColor: config.backgroundColor,
                 foregroundColor: config.foregroundColor
             ))

--- a/Sources/CardliftKit/Models/Tenant.swift
+++ b/Sources/CardliftKit/Models/Tenant.swift
@@ -9,37 +9,15 @@ import Foundation
 
 
 struct Tenant: Codable, Identifiable {
-    let id, slug: String
-    let name, card: String
-    // let foreground_color, background_color: String
-    // let app_store_url: String
-
-    enum CodingKeys: String, CodingKey {
-        case id, slug, name, card
-    }
+    let id, slug, name, bundleIdentifier: String
+    let appStoreLink: String
+    let cardImage: String
+    let foregroundColor, backgroundColor: ConfigColor
+    let buttonRadius: Double
+    let upsellLabel, title: String
+    let features: [String]
 }
 
-class JSONNull: Codable, Hashable {
-
-    public static func == (lhs: JSONNull, rhs: JSONNull) -> Bool {
-            return true
-    }
-
-    public func hash(into hasher: inout Hasher) {
-        hasher.combine(0)
-    }
-
-    public init() {}
-
-    public required init(from decoder: Decoder) throws {
-            let container = try decoder.singleValueContainer()
-            if !container.decodeNil() {
-                    throw DecodingError.typeMismatch(JSONNull.self, DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "Wrong type for JSONNull"))
-            }
-    }
-
-    public func encode(to encoder: Encoder) throws {
-            var container = encoder.singleValueContainer()
-            try container.encodeNil()
-    }
+struct ConfigColor: Codable {
+    let r, g, b: Double
 }

--- a/Sources/CardliftKit/Models/Tenant.swift
+++ b/Sources/CardliftKit/Models/Tenant.swift
@@ -8,14 +8,14 @@
 import Foundation
 
 
-struct Tenant: Codable {
+struct Tenant: Codable, Identifiable {
     let id, slug: String
-    let name, card: String?
-    let buttonColor, buttonBackground: String
-    let autofillBackgroundColor, autofillTextColor: String
+    let name, card: String
+    // let foreground_color, background_color: String
+    // let app_store_url: String
 
     enum CodingKeys: String, CodingKey {
-        case id, slug, name, card, buttonColor, buttonBackground, autofillBackgroundColor, autofillTextColor
+        case id, slug, name, card
     }
 }
 

--- a/Sources/CardliftKit/Models/Tenant.swift
+++ b/Sources/CardliftKit/Models/Tenant.swift
@@ -1,0 +1,45 @@
+//
+//  Tenant.swift
+//  CardliftKit
+//
+//  Created by Ray Nirola on 11/01/25.
+//
+
+import Foundation
+
+
+struct Tenant: Codable {
+    let id, slug: String
+    let name, card: String?
+    let buttonColor, buttonBackground: String
+    let autofillBackgroundColor, autofillTextColor: String
+
+    enum CodingKeys: String, CodingKey {
+        case id, slug, name, card, buttonColor, buttonBackground, autofillBackgroundColor, autofillTextColor
+    }
+}
+
+class JSONNull: Codable, Hashable {
+
+    public static func == (lhs: JSONNull, rhs: JSONNull) -> Bool {
+            return true
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(0)
+    }
+
+    public init() {}
+
+    public required init(from decoder: Decoder) throws {
+            let container = try decoder.singleValueContainer()
+            if !container.decodeNil() {
+                    throw DecodingError.typeMismatch(JSONNull.self, DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "Wrong type for JSONNull"))
+            }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+            var container = encoder.singleValueContainer()
+            try container.encodeNil()
+    }
+}

--- a/Sources/CardliftKit/Models/UpsellButtonConfig.swift
+++ b/Sources/CardliftKit/Models/UpsellButtonConfig.swift
@@ -8,23 +8,18 @@ import SwiftUI
 
 /**
  A configuration for the upsell button.
- - Parameter text: The button text.
+ Keeping it as minimalist as possible to reduce friction
  - Parameter backgroundColor: The button background color.
  - Parameter foregroundColor: The button text color.
- - Parameter cornerRadius: The button corner radius.
  */
 public struct UpsellButtonConfig {
-    var text: String
     var backgroundColor: Color
     var foregroundColor: Color
 
     public init(
-        text: String,
         backgroundColor: Color = .blue,
-        foregroundColor: Color = .white,
-        cornerRadius: CGFloat = 8
+        foregroundColor: Color = .white
     ) {
-        self.text = text
         self.backgroundColor = backgroundColor
         self.foregroundColor = foregroundColor
     }

--- a/Sources/CardliftKit/Models/UpsellButtonConfig.swift
+++ b/Sources/CardliftKit/Models/UpsellButtonConfig.swift
@@ -1,0 +1,31 @@
+//
+//  UpsellButtonConfig.swift
+//  CardliftKit
+//
+//  Created by Ray Nirola on 11/01/25.
+//
+import SwiftUI
+
+/**
+ A configuration for the upsell button.
+ - Parameter text: The button text.
+ - Parameter backgroundColor: The button background color.
+ - Parameter foregroundColor: The button text color.
+ - Parameter cornerRadius: The button corner radius.
+ */
+public struct UpsellButtonConfig {
+    var text: String
+    var backgroundColor: Color
+    var foregroundColor: Color
+
+    public init(
+        text: String,
+        backgroundColor: Color = .blue,
+        foregroundColor: Color = .white,
+        cornerRadius: CGFloat = 8
+    ) {
+        self.text = text
+        self.backgroundColor = backgroundColor
+        self.foregroundColor = foregroundColor
+    }
+}

--- a/Sources/CardliftKit/Upsell.swift
+++ b/Sources/CardliftKit/Upsell.swift
@@ -11,8 +11,8 @@ import SwiftUI
 public class TenantViewModel: ObservableObject {
     @Published var tenant: Tenant?
 
-    func fetchTenant() {
-        let url = URL(string: "https://api.cardlift.co/v1/tenants/heb")!
+    func fetchTenant(slug: String = "acme") {
+        let url = URL(string: "https://api.cardlift.co/v1/tenants/\(slug)")!
 
         URLSession.shared.dataTask(with: url) { data, response, error in
             if let error = error {
@@ -43,7 +43,6 @@ public class TenantViewModel: ObservableObject {
  A view that prompts users to install the iOS extension.
  - Parameter appStoreURL: The URL to the App Store page for the iOS extension.
  - Parameter buttonConfig: The configuration for the button.
- - text: The button text.
  - backgroundColor: The button background color.
  - foregroundColor: The button text color.
  - Returns: A button that, when tapped, opens a sheet with an upsell message.
@@ -51,11 +50,11 @@ public class TenantViewModel: ObservableObject {
 public struct Upsell: View {
     @State private var showSheet = false
     @StateObject var tenantViewModel = TenantViewModel()
-    var appStoreURL: URL
+    var slug: String
     var buttonConfig: UpsellButtonConfig
 
-    public init( appStoreURL: URL, buttonConfig: UpsellButtonConfig) {
-        self.appStoreURL = appStoreURL
+    public init( slug: String, buttonConfig: UpsellButtonConfig) {
+        self.slug = slug
         self.buttonConfig = buttonConfig
     }
 
@@ -80,11 +79,11 @@ public struct Upsell: View {
         .background(buttonConfig.backgroundColor)
         .cornerRadius(40)
         .sheet(isPresented: $showSheet) {
-            UpsellSheet(appStoreURL: appStoreURL)
+            UpsellSheet()
                 .environmentObject(tenantViewModel)
         }
         .onAppear {
-            tenantViewModel.fetchTenant()
+            tenantViewModel.fetchTenant(slug: slug)
         }
 
     }
@@ -92,12 +91,6 @@ public struct Upsell: View {
     struct UpsellSheet: View {
         @Environment(\.openURL) var openURL
         @EnvironmentObject var tenantViewModel: TenantViewModel
-
-        var appStoreURL: URL
-
-        init(appStoreURL: URL) {
-            self.appStoreURL = appStoreURL
-        }
 
         var body: some View {
             VStack {
@@ -165,7 +158,7 @@ public struct Upsell: View {
 
                 VStack {
                     Button(action: {
-                        openURL(appStoreURL)
+                        openURL(URL(string:  "")!)
                     }) {
                         Text("Add \(tenantViewModel.tenant?.name ?? "") to your wallet")
                             .font(.system(size: 20, weight: .semibold))
@@ -199,7 +192,7 @@ public struct Upsell: View {
 /**
  A view that displays a shimmering effect using a rounded rectangle.
  The shimmer effect animates the opacity of the rectangle between 0.1 and 0.5.
- 
+
  The `Shimmer` view uses a `State` property `isAnimating` to control the animation.
  When the view appears, it starts an infinite linear animation that toggles the `isAnimating`
  state, creating a shimmering effect.

--- a/Sources/CardliftKit/Upsell.swift
+++ b/Sources/CardliftKit/Upsell.swift
@@ -1,0 +1,160 @@
+import SwiftUI
+
+/**
+ A view that prompts users to install the iOS extension.
+ - Parameter appStoreURL: The URL to the App Store page for the iOS extension.
+ - Parameter buttonConfig: The configuration for the button.
+ - text: The button text.
+ - backgroundColor: The button background color.
+ - foregroundColor: The button text color.
+ - cornerRadius: The button corner radius.
+ - Returns: A button that, when tapped, opens a sheet with an upsell message.
+ */
+public struct Upsell: View {
+    @State private var showSheet = false
+    var appStoreURL: URL
+    var buttonConfig: UpsellButtonConfig
+    
+    public init( appStoreURL: URL, buttonConfig: UpsellButtonConfig) {
+        self.appStoreURL = appStoreURL
+        self.buttonConfig = buttonConfig
+    }
+    
+    public var body: some View {
+        Button(action: {
+            self.showSheet.toggle()
+        }) {
+            Text(buttonConfig.text)
+                .padding()
+                .frame(maxWidth: .infinity)
+                .foregroundColor(buttonConfig.foregroundColor)
+        }
+        .frame(width: UIScreen.main.bounds.width - 40)
+        .background(buttonConfig.backgroundColor)
+        .cornerRadius(40)
+        .sheet(isPresented: $showSheet) {
+            UpsellSheet(appStoreURL: appStoreURL)
+        }
+        
+    }
+    
+    struct UpsellSheet: View {
+        @Environment(\.openURL) var openURL
+        
+        var appStoreURL: URL
+        
+        init(appStoreURL: URL) {
+            self.appStoreURL = appStoreURL
+        }
+        
+        var body: some View {
+            VStack {
+                Spacer()
+                
+                Text("Simplify your checkout with our Safari Extension")
+                    .foregroundColor(Color(red: 55/255, green: 55/255, blue: 55/255))
+                    .font(.system(size: 32, weight: .bold))
+                    .tracking(0.3)
+                    .lineSpacing(0.8)
+                    .multilineTextAlignment(.center)
+                    .frame(maxWidth: 300, alignment: .center)
+                    .padding()
+                
+                AsyncImage(url: URL(string: "https://cardlift.s3.amazonaws.com/brand/heb/heb-card.png")) { image in
+                    image
+                        .resizable()
+                        .aspectRatio(contentMode: .fit)
+                        .frame(width: UIScreen.main.bounds.width - 80)
+                        .padding()
+                } placeholder: {
+                    Shimmer()
+                        .frame(width: UIScreen.main.bounds.width - 80, height: 190)
+                        .padding()
+                }
+                
+                Group {
+                    HStack {
+                        Spacer()
+                        Image(systemName: "checkmark.circle.fill")
+                            .foregroundColor(Color(red: 110/255, green: 100/255, blue: 100/255))
+                            .frame(width: 4, height: 4)
+                        Text("Checkout 2x quicker")
+                            .font(.system(size: 16, weight: .medium))
+                            .padding(.leading, 6)
+                            .foregroundColor(Color(red: 140/255, green: 140/255, blue: 140/255))
+                        Spacer()
+                    }.padding(.top, 12)
+                    HStack {
+                        Spacer()
+                        Image(systemName: "checkmark.circle.fill")
+                            .foregroundColor(Color(red: 110/255, green: 100/255, blue: 100/255))
+                            .frame(width: 4, height: 4)
+                        Text("Change your card at frequent sites")
+                            .font(.system(size: 16, weight: .medium))
+                            .padding(.leading, 6)
+                            .foregroundColor(Color(red: 140/255, green: 140/255, blue: 140/255))
+                        Spacer()
+                    }
+                    HStack {
+                        Spacer()
+                        Image(systemName: "checkmark.circle.fill")
+                            .foregroundColor(Color(red: 110/255, green: 100/255, blue: 100/255))
+                            .frame(width: 4, height: 4)
+                        Text("Earn more points by using this card more")
+                            .font(.system(size: 16, weight: .medium))
+                            .padding(.leading, 6)
+                            .foregroundColor(Color(red: 140/255, green: 140/255, blue: 140/255))
+                        
+                        Spacer()
+                    }
+                }
+                
+                Spacer()
+                
+                VStack {
+                    Button(action: {
+                        openURL(appStoreURL)
+                    }) {
+                        Text("Add to Safari")
+                            .font(.system(size: 20, weight: .semibold))
+                            .padding()
+                            .frame(maxWidth: UIScreen.main.bounds.width - 40)
+                            .background(Color(red: 218/255, green: 41/255, blue: 36/255))
+                            .foregroundColor(.white)
+                            .cornerRadius(40)
+                    }
+                    
+                    HStack {
+                        Spacer()
+                        Image(systemName: "lock.fill")
+                            .foregroundColor(.gray)
+                        Text("End to end encrypted on your device")
+                            .font(.caption)
+                            .fontWeight(.medium)
+                            .foregroundColor(.gray)
+                        Spacer()
+                    }.padding(.top, 4)
+                }
+                
+            }
+            .padding()
+        }
+    }
+}
+
+
+
+struct Shimmer: View {
+    @State private var isAnimating = false
+    
+    var body: some View {
+        RoundedRectangle(cornerRadius: 10)
+            .fill(Color(UIColor.lightGray))
+            .opacity(isAnimating ? 0.5 : 0.1)
+            .onAppear {
+                withAnimation(Animation.linear(duration: 2).repeatForever(autoreverses: true)) {
+                    isAnimating = true
+                }
+            }
+    }
+}

--- a/Sources/CardliftKit/Upsell.swift
+++ b/Sources/CardliftKit/Upsell.swift
@@ -2,29 +2,29 @@ import SwiftUI
 
 /**
  A view model that fetches and holds tenant data.
-`TenantViewModel` is an observable object that fetches tenant data from a remote server and publishes it.
+ `TenantViewModel` is an observable object that fetches tenant data from a remote server and publishes it.
  - Properties:
-    - tenant: The tenant data fetched from the server. It is an optional `Tenant` object.
+ - tenant: The tenant data fetched from the server. It is an optional `Tenant` object.
  - Methods:
-    - fetchTenant(): Fetches tenant data from a predefined URL and updates the `tenant` property. Handles network errors and JSON decoding errors.
-*/
+ - fetchTenant(): Fetches tenant data from a predefined URL and updates the `tenant` property. Handles network errors and JSON decoding errors.
+ */
 public class TenantViewModel: ObservableObject {
     @Published var tenant: Tenant?
-
+    
     func fetchTenant(slug: String = "acme") {
-        let url = URL(string: "https://api.cardlift.co/v1/tenants/\(slug)")!
-
+        let url = URL(string: "https://api.cardlift.co/v1/tenants/\(slug)/ios")!
+        
         URLSession.shared.dataTask(with: url) { data, response, error in
             if let error = error {
                 print("Network error: \(error.localizedDescription)")
                 return
             }
-
+            
             guard let data = data else {
                 print("No data returned from server")
                 return
             }
-
+            
             let decoder = JSONDecoder()
             do {
                 let tenant = try decoder.decode(Tenant.self, from: data)
@@ -52,12 +52,12 @@ public struct Upsell: View {
     @StateObject var tenantViewModel = TenantViewModel()
     var slug: String
     var buttonConfig: UpsellButtonConfig
-
+    
     public init( slug: String, buttonConfig: UpsellButtonConfig) {
         self.slug = slug
         self.buttonConfig = buttonConfig
     }
-
+    
     public var body: some View {
         Button(action: {
             self.showSheet.toggle()
@@ -85,18 +85,18 @@ public struct Upsell: View {
         .onAppear {
             tenantViewModel.fetchTenant(slug: slug)
         }
-
+        
     }
-
+    
     struct UpsellSheet: View {
         @Environment(\.openURL) var openURL
         @EnvironmentObject var tenantViewModel: TenantViewModel
-
+        
         var body: some View {
             VStack {
                 Spacer()
-
-                Text("Simplify your checkout with our Safari Extension")
+                
+                Text(tenantViewModel.tenant!.title)
                     .foregroundColor(Color(red: 55/255, green: 55/255, blue: 55/255))
                     .font(.system(size: 32, weight: .bold))
                     .tracking(0.3)
@@ -104,8 +104,8 @@ public struct Upsell: View {
                     .multilineTextAlignment(.center)
                     .frame(maxWidth: 300, alignment: .center)
                     .padding()
-
-                AsyncImage(url: URL(string: tenantViewModel.tenant?.card ?? "")) { image in
+                
+                AsyncImage(url: URL(string: tenantViewModel.tenant?.cardImage ?? "")) { image in
                     image
                         .resizable()
                         .aspectRatio(contentMode: .fit)
@@ -116,59 +116,40 @@ public struct Upsell: View {
                         .frame(width: UIScreen.main.bounds.width - 80, height: 190)
                         .padding()
                 }
-
+                
                 Group {
-                    HStack {
-                        Spacer()
-                        Image(systemName: "checkmark.circle.fill")
-                            .foregroundColor(Color(red: 110/255, green: 100/255, blue: 100/255))
-                            .frame(width: 4, height: 4)
-                        Text("Checkout 2x quicker")
-                            .font(.system(size: 16, weight: .medium))
-                            .padding(.leading, 6)
-                            .foregroundColor(Color(red: 140/255, green: 140/255, blue: 140/255))
-                        Spacer()
-                    }.padding(.top, 12)
-                    HStack {
-                        Spacer()
-                        Image(systemName: "checkmark.circle.fill")
-                            .foregroundColor(Color(red: 110/255, green: 100/255, blue: 100/255))
-                            .frame(width: 4, height: 4)
-                        Text("Change your card at frequent sites")
-                            .font(.system(size: 16, weight: .medium))
-                            .padding(.leading, 6)
-                            .foregroundColor(Color(red: 140/255, green: 140/255, blue: 140/255))
-                        Spacer()
-                    }
-                    HStack {
-                        Spacer()
-                        Image(systemName: "checkmark.circle.fill")
-                            .foregroundColor(Color(red: 110/255, green: 100/255, blue: 100/255))
-                            .frame(width: 4, height: 4)
-                        Text("Earn more points by using this card more")
-                            .font(.system(size: 16, weight: .medium))
-                            .padding(.leading, 6)
-                            .foregroundColor(Color(red: 140/255, green: 140/255, blue: 140/255))
-
-                        Spacer()
+                    ForEach(tenantViewModel.tenant!.features, id: \.self) { feature in
+                        HStack {
+                            Spacer()
+                            Image(systemName: "checkmark.circle.fill")
+                                .foregroundColor(Color(red: 110/255, green: 100/255, blue: 100/255))
+                                .frame(width: 4, height: 4)
+                            Text(feature)
+                                .font(.system(size: 16, weight: .medium))
+                                .padding(.leading, 6)
+                                .foregroundColor(Color(red: 140/255, green: 140/255, blue: 140/255))
+                            Spacer()
+                        }
                     }
                 }
-
+                
                 Spacer()
-
+                
                 VStack {
                     Button(action: {
-                        openURL(URL(string:  "")!)
+                        openURL(URL(string: tenantViewModel.tenant!.appStoreLink)!)
                     }) {
-                        Text("Add \(tenantViewModel.tenant?.name ?? "") to your wallet")
+                        let bGColor = tenantViewModel.tenant!.backgroundColor
+                        
+                        Text("Add \(tenantViewModel.tenant!.name) to your wallet")
                             .font(.system(size: 20, weight: .semibold))
                             .padding()
                             .frame(maxWidth: UIScreen.main.bounds.width - 40)
-                            .background(Color(red: 218/255, green: 41/255, blue: 36/255))
+                            .background(Color(red: Double(bGColor.r/255), green: bGColor.g/255, blue: bGColor.b/255))
                             .foregroundColor(.white)
-                            .cornerRadius(40)
+                            .cornerRadius(tenantViewModel.tenant!.buttonRadius)
                     }
-
+                    
                     HStack {
                         Spacer()
                         Image(systemName: "lock.fill")
@@ -180,7 +161,7 @@ public struct Upsell: View {
                         Spacer()
                     }.padding(.top, 4)
                 }
-
+                
             }
             .padding()
         }
@@ -192,14 +173,14 @@ public struct Upsell: View {
 /**
  A view that displays a shimmering effect using a rounded rectangle.
  The shimmer effect animates the opacity of the rectangle between 0.1 and 0.5.
-
+ 
  The `Shimmer` view uses a `State` property `isAnimating` to control the animation.
  When the view appears, it starts an infinite linear animation that toggles the `isAnimating`
  state, creating a shimmering effect.
-*/
+ */
 struct Shimmer: View {
     @State private var isAnimating = false
-
+    
     var body: some View {
         RoundedRectangle(cornerRadius: 10)
             .fill(Color(UIColor.lightGray))

--- a/Sources/CardliftKit/Upsell.swift
+++ b/Sources/CardliftKit/Upsell.swift
@@ -1,56 +1,108 @@
 import SwiftUI
 
 /**
+ A view model that fetches and holds tenant data.
+`TenantViewModel` is an observable object that fetches tenant data from a remote server and publishes it.
+ - Properties:
+    - tenant: The tenant data fetched from the server. It is an optional `Tenant` object.
+ - Methods:
+    - fetchTenant(): Fetches tenant data from a predefined URL and updates the `tenant` property. Handles network errors and JSON decoding errors.
+*/
+public class TenantViewModel: ObservableObject {
+    @Published var tenant: Tenant?
+
+    func fetchTenant() {
+        let url = URL(string: "https://api.cardlift.co/v1/tenants/heb")!
+
+        URLSession.shared.dataTask(with: url) { data, response, error in
+            if let error = error {
+                print("Network error: \(error.localizedDescription)")
+                return
+            }
+
+            guard let data = data else {
+                print("No data returned from server")
+                return
+            }
+
+            let decoder = JSONDecoder()
+            do {
+                let tenant = try decoder.decode(Tenant.self, from: data)
+                DispatchQueue.main.async {
+                    self.tenant = tenant
+                }
+            } catch {
+                print("Decoding error: \(error.localizedDescription)")
+                print("Failed data: \(String(data: data, encoding: .utf8) ?? "Unreadable data")")
+            }
+        }.resume()
+    }
+}
+
+/**
  A view that prompts users to install the iOS extension.
  - Parameter appStoreURL: The URL to the App Store page for the iOS extension.
  - Parameter buttonConfig: The configuration for the button.
  - text: The button text.
  - backgroundColor: The button background color.
  - foregroundColor: The button text color.
- - cornerRadius: The button corner radius.
  - Returns: A button that, when tapped, opens a sheet with an upsell message.
  */
 public struct Upsell: View {
     @State private var showSheet = false
+    @StateObject var tenantViewModel = TenantViewModel()
     var appStoreURL: URL
     var buttonConfig: UpsellButtonConfig
-    
+
     public init( appStoreURL: URL, buttonConfig: UpsellButtonConfig) {
         self.appStoreURL = appStoreURL
         self.buttonConfig = buttonConfig
     }
-    
+
     public var body: some View {
         Button(action: {
             self.showSheet.toggle()
         }) {
-            Text(buttonConfig.text)
-                .padding()
-                .frame(maxWidth: .infinity)
-                .foregroundColor(buttonConfig.foregroundColor)
+            if tenantViewModel.tenant == nil {
+                ProgressView()
+                    .progressViewStyle(CircularProgressViewStyle(tint: buttonConfig.foregroundColor))
+                    .padding()
+                    .frame(maxWidth: .infinity)
+                    .foregroundColor(buttonConfig.foregroundColor)
+            } else {
+                Text("Add \(tenantViewModel.tenant?.name ?? "") to Safari")
+                    .padding()
+                    .frame(maxWidth: .infinity)
+                    .foregroundColor(buttonConfig.foregroundColor)
+            }
         }
         .frame(width: UIScreen.main.bounds.width - 40)
         .background(buttonConfig.backgroundColor)
         .cornerRadius(40)
         .sheet(isPresented: $showSheet) {
             UpsellSheet(appStoreURL: appStoreURL)
+                .environmentObject(tenantViewModel)
         }
-        
+        .onAppear {
+            tenantViewModel.fetchTenant()
+        }
+
     }
-    
+
     struct UpsellSheet: View {
         @Environment(\.openURL) var openURL
-        
+        @EnvironmentObject var tenantViewModel: TenantViewModel
+
         var appStoreURL: URL
-        
+
         init(appStoreURL: URL) {
             self.appStoreURL = appStoreURL
         }
-        
+
         var body: some View {
             VStack {
                 Spacer()
-                
+
                 Text("Simplify your checkout with our Safari Extension")
                     .foregroundColor(Color(red: 55/255, green: 55/255, blue: 55/255))
                     .font(.system(size: 32, weight: .bold))
@@ -59,8 +111,8 @@ public struct Upsell: View {
                     .multilineTextAlignment(.center)
                     .frame(maxWidth: 300, alignment: .center)
                     .padding()
-                
-                AsyncImage(url: URL(string: "https://cardlift.s3.amazonaws.com/brand/heb/heb-card.png")) { image in
+
+                AsyncImage(url: URL(string: tenantViewModel.tenant?.card ?? "")) { image in
                     image
                         .resizable()
                         .aspectRatio(contentMode: .fit)
@@ -71,7 +123,7 @@ public struct Upsell: View {
                         .frame(width: UIScreen.main.bounds.width - 80, height: 190)
                         .padding()
                 }
-                
+
                 Group {
                     HStack {
                         Spacer()
@@ -104,18 +156,18 @@ public struct Upsell: View {
                             .font(.system(size: 16, weight: .medium))
                             .padding(.leading, 6)
                             .foregroundColor(Color(red: 140/255, green: 140/255, blue: 140/255))
-                        
+
                         Spacer()
                     }
                 }
-                
+
                 Spacer()
-                
+
                 VStack {
                     Button(action: {
                         openURL(appStoreURL)
                     }) {
-                        Text("Add to Safari")
+                        Text("Add \(tenantViewModel.tenant?.name ?? "") to your wallet")
                             .font(.system(size: 20, weight: .semibold))
                             .padding()
                             .frame(maxWidth: UIScreen.main.bounds.width - 40)
@@ -123,7 +175,7 @@ public struct Upsell: View {
                             .foregroundColor(.white)
                             .cornerRadius(40)
                     }
-                    
+
                     HStack {
                         Spacer()
                         Image(systemName: "lock.fill")
@@ -135,7 +187,7 @@ public struct Upsell: View {
                         Spacer()
                     }.padding(.top, 4)
                 }
-                
+
             }
             .padding()
         }
@@ -144,9 +196,17 @@ public struct Upsell: View {
 
 
 
+/**
+ A view that displays a shimmering effect using a rounded rectangle.
+ The shimmer effect animates the opacity of the rectangle between 0.1 and 0.5.
+ 
+ The `Shimmer` view uses a `State` property `isAnimating` to control the animation.
+ When the view appears, it starts an infinite linear animation that toggles the `isAnimating`
+ state, creating a shimmering effect.
+*/
 struct Shimmer: View {
     @State private var isAnimating = false
-    
+
     var body: some View {
         RoundedRectangle(cornerRadius: 10)
             .fill(Color(UIColor.lightGray))


### PR DESCRIPTION
This pull request introduces a new upsell feature to the `CardliftKit` SDK, including the addition of a new view and configuration model for the upsell button, as well as the necessary imports and documentation updates. The most important changes are as follows:

### New Feature: Upsell View

* Added `Upsell` struct to create a view that prompts users to install the iOS extension, complete with a button and a sheet displaying an upsell message (`Sources/CardliftKit/Upsell.swift`).
* Introduced `UpsellButtonConfig` struct to configure the upsell button's appearance, including text, background color, and foreground color (`Sources/CardliftKit/Models/UpsellButtonConfig.swift`).

### Updates to `CardliftKit`

* Added `UpSellView` method to the `CardliftKit` enum to expose the new upsell view as a public API (`Sources/CardliftKit/CardliftKit.swift`).
* Imported `SwiftUI` in `CardliftKit.swift` to support the new upsell view (`Sources/CardliftKit/CardliftKit.swift`).