### PR TITLE
feat: conditional prompt based on session token

### DIFF
--- a/Sources/CardliftKit/CardliftKit.swift
+++ b/Sources/CardliftKit/CardliftKit.swift
@@ -19,6 +19,7 @@ public enum CardliftKit {
      */
     public static func setup(router: WebExtensionMessageRouter) {
         router.registerHandler(GetCardMetaDataHandler())
+        router.registerHandler(OnInstallMessageHandler())
         // Other handlers here...
     }
     
@@ -43,6 +44,20 @@ public enum CardliftKit {
         SharedData.clear()
     }
     
+    /**
+     Get account info
+     */
+    public static func getAccountInfo() -> AccountInfo? {
+        return SharedData.accountInfo
+    }
+
+    /**
+     Save account info
+    */
+    public static func saveAccountInfo(account: AccountInfo){
+        SharedData.accountInfo = account
+    }
+
     /**
      Validates all fields in the provided `CardliftCardFormData` and returns a dictionary of errors.
      - Parameter formData: The form data to validate.

--- a/Sources/CardliftKit/MessageHandlers/OnInstallMessageHandler.swift
+++ b/Sources/CardliftKit/MessageHandlers/OnInstallMessageHandler.swift
@@ -1,0 +1,27 @@
+//
+//  OnInstallMessageHandler.swift
+//  CardliftKit
+//
+//  Created by Ray Nirola on 16/01/25.
+//
+
+import Foundation
+
+/*
+ A handler responsible for processing messages related to saving and retriving account info / token
+ Conforms to the `MessageHandler` protocol.
+ */
+struct OnInstallMessageHandler: MessageHandler {
+    static let name = "account-on-install"
+    
+    struct MessageData: Codable {
+        public let token : String
+    }
+    
+    typealias MessageResponse = Bool
+    
+    func handle(data: MessageData) throws -> MessageResponse {
+        SharedData.accountInfo = AccountInfo(token: data.token)
+        return true
+    }
+}

--- a/Sources/CardliftKit/MessageHandlers/OnInstallMessageHandler.swift
+++ b/Sources/CardliftKit/MessageHandlers/OnInstallMessageHandler.swift
@@ -7,21 +7,29 @@
 
 import Foundation
 
+struct AccountTokenResponse: Codable {
+    var success: Bool
+}
+
 /*
- A handler responsible for processing messages related to saving and retriving account info / token
+ A handler responsible for processing messages related to saving and retrieving account info / token
  Conforms to the `MessageHandler` protocol.
  */
 struct OnInstallMessageHandler: MessageHandler {
-    static let name = "account-on-install"
+    static let name = "sendAccountToken"
+    
+    typealias MessageResponse = AccountTokenResponse
     
     struct MessageData: Codable {
-        public let token : String
+        var token: String
     }
     
-    typealias MessageResponse = Bool
-    
     func handle(data: MessageData) throws -> MessageResponse {
+        guard !data.token.isEmpty else {
+            throw NSError(domain: "OnInstallMessageHandler", code: 400, userInfo: [NSLocalizedDescriptionKey: "Token cannot be empty"])
+        }
+        
         SharedData.accountInfo = AccountInfo(token: data.token)
-        return true
+        return AccountTokenResponse(success: true)
     }
 }

--- a/Sources/CardliftKit/Models/AccountInfo.swift
+++ b/Sources/CardliftKit/Models/AccountInfo.swift
@@ -1,0 +1,10 @@
+//
+//  AccountInfo.swift
+//  CardliftKit
+//
+//  Created by Ray Nirola on 16/01/25.
+//
+
+public struct AccountInfo: Codable {
+    public let token: String
+}

--- a/Sources/CardliftKit/Upsell.swift
+++ b/Sources/CardliftKit/Upsell.swift
@@ -40,6 +40,20 @@ public class TenantViewModel: ObservableObject {
 }
 
 /**
+ Data view model for fetching user info from keychain
+ */
+public class AccountInfoViewModel: ObservableObject {
+    @Published var account: AccountInfo?
+
+    public func getAccount() {
+        if let data = SharedData.accountInfo {
+            account = data
+            return
+        }
+    }
+}
+
+/**
  A view that prompts users to install the iOS extension.
  - Parameter appStoreURL: The URL to the App Store page for the iOS extension.
  - Parameter buttonConfig: The configuration for the button.
@@ -51,7 +65,8 @@ public struct Upsell: View {
     var slug: String
     @Binding var isPresented: Bool
     @StateObject var tenantViewModel = TenantViewModel()
-   
+    @StateObject var accountViewModel = AccountInfoViewModel()
+    
     public init(slug: String, isPresented: Binding<Bool>) {
         self.slug = slug
         self._isPresented = isPresented
@@ -60,7 +75,7 @@ public struct Upsell: View {
     public var body: some View {
         EmptyView()
             .sheet(isPresented: $isPresented) {
-                if let tenant = tenantViewModel.tenant {
+                if let tenant = tenantViewModel.tenant, accountViewModel.account == nil {
                     UpsellSheet(tenant: tenant)
                 } else {
                     EmptyView()
@@ -68,6 +83,7 @@ public struct Upsell: View {
             }
             .onAppear {
                 tenantViewModel.fetchTenant(slug: slug)
+                accountViewModel.getAccount()
             }
         
     }

--- a/Sources/CardliftKit/Upsell.swift
+++ b/Sources/CardliftKit/Upsell.swift
@@ -67,6 +67,20 @@ public struct Upsell: View {
     @StateObject var tenantViewModel = TenantViewModel()
     @StateObject var accountViewModel = AccountInfoViewModel()
     
+    private var isPresentedBinding: Binding<Bool> {
+        Binding(
+            get: {
+                NSLog("Debug: Upsell isPresented: \(isPresented)");
+                NSLog("Debug: Upsell Tenant: \(String(describing: tenantViewModel.tenant))");
+                NSLog("Debug: Upsell Account: \(String(describing: accountViewModel.account))");
+                return tenantViewModel.tenant != nil && accountViewModel.account == nil
+            },
+            set: { newValue in
+                isPresented = newValue
+            }
+        )
+    }
+    
     public init(slug: String, isPresented: Binding<Bool>) {
         self.slug = slug
         self._isPresented = isPresented
@@ -74,12 +88,8 @@ public struct Upsell: View {
     
     public var body: some View {
         EmptyView()
-            .sheet(isPresented: $isPresented) {
-                if let tenant = tenantViewModel.tenant, accountViewModel.account == nil {
-                    UpsellSheet(tenant: tenant)
-                } else {
-                    EmptyView()
-                }
+            .sheet(isPresented: isPresentedBinding) {
+                UpsellSheet(tenant: tenantViewModel.tenant!)
             }
             .onAppear {
                 tenantViewModel.fetchTenant(slug: slug)

--- a/Sources/CardliftKit/Utils/SharedData.swift
+++ b/Sources/CardliftKit/Utils/SharedData.swift
@@ -23,6 +23,7 @@ enum SharedData {
      */
     enum Keys: String {
         case cardMetaDataKey
+        case accountInfoKey
         var key: String { rawValue }
     }
 
@@ -41,6 +42,23 @@ enum SharedData {
             if let newValue = newValue,
                let data = try? JSONEncoder().encode(newValue) {
                 setKeychainData(data, for: Keys.cardMetaDataKey.key)
+            } else {
+                removeKeychainData(for: Keys.cardMetaDataKey.key)
+            }
+        }
+    }
+    
+    static var accountInfo: AccountInfo? {
+        get {
+            guard let data = getKeychainData(for: "accountInfo") else {
+                return nil
+            }
+            return try? JSONDecoder().decode(AccountInfo.self, from: data)
+        }
+        set {
+            if let newValue = newValue,
+               let data = try? JSONEncoder().encode(newValue) {
+                setKeychainData(data, for: Keys.accountInfoKey.key)
             } else {
                 removeKeychainData(for: Keys.cardMetaDataKey.key)
             }

--- a/Sources/CardliftKit/Utils/SharedData.swift
+++ b/Sources/CardliftKit/Utils/SharedData.swift
@@ -50,7 +50,7 @@ enum SharedData {
     
     static var accountInfo: AccountInfo? {
         get {
-            guard let data = getKeychainData(for: "accountInfo") else {
+            guard let data = getKeychainData(for: Keys.accountInfoKey.key) else {
                 return nil
             }
             return try? JSONDecoder().decode(AccountInfo.self, from: data)

--- a/Sources/CardliftKit/WebExtensionMessageRouter.swift
+++ b/Sources/CardliftKit/WebExtensionMessageRouter.swift
@@ -43,11 +43,9 @@ extension Decodable {
     }
 }
 
-// Message Router
 public class WebExtensionMessageRouter {
     private var handlers: [String: (Any) throws -> Any] = [:]
 
-    // Register a handler
     public func registerHandler<H: MessageHandler>(_ handler: H) {
         handlers[H.name] = { rawData in
             guard let dictionary = rawData as? [String: Any],
@@ -59,7 +57,6 @@ public class WebExtensionMessageRouter {
         }
     }
 
-    // Process a message
     public func handleMessage(name: String, data: Any, sendResponse: @escaping (Any) -> Void) {
         guard let handler = handlers[name] else {
             return sendResponse(["type": "error", "data": "name: \(name) not found"])
@@ -69,7 +66,6 @@ public class WebExtensionMessageRouter {
             let response = try handler(data)
             sendResponse(response)
         } catch {
-            print("Error in handler \(name): \(error)")
             sendResponse(["type": "error", "data": error.localizedDescription])
         }
     }


### PR DESCRIPTION
This pull request introduces several new features and improvements to the `CardliftKit` module, primarily focusing on account information management and message handling. The most important changes include adding new message handlers, creating account-related models and view models, and updating the `Upsell` view to utilize these new components.

### New Features:
* Added `OnInstallMessageHandler` to handle messages related to saving and retrieving account information (`Sources/CardliftKit/MessageHandlers/OnInstallMessageHandler.swift`).
* Introduced `AccountInfo` model to store account token information (`Sources/CardliftKit/Models/AccountInfo.swift`).
* Created `AccountInfoViewModel` to fetch user info from the keychain (`Sources/CardliftKit/Upsell.swift`).

### Enhancements:
* Updated `CardliftKit` to register the new `OnInstallMessageHandler` and provide methods to get and save account information (`Sources/CardliftKit/CardliftKit.swift`). [[1]](diffhunk://#diff-9ad319b04789d4e35442182cf0d52d8dcf4d91e1407b8fc96bf65b9428f46fbbR22) [[2]](diffhunk://#diff-9ad319b04789d4e35442182cf0d52d8dcf4d91e1407b8fc96bf65b9428f46fbbR47-R60)
* Modified `Upsell` view to use `AccountInfoViewModel` and added logging for debugging purposes (`Sources/CardliftKit/Upsell.swift`). [[1]](diffhunk://#diff-ced0999dcec87799a43f6bfd4b49930ecb8b45a759cefee9a1f078f3e3ba9a43R68-R82) [[2]](diffhunk://#diff-ced0999dcec87799a43f6bfd4b49930ecb8b45a759cefee9a1f078f3e3ba9a43L62-R96)
* Added `accountInfo` key to `SharedData` and implemented getter and setter for account information in the keychain (`Sources/CardliftKit/Utils/SharedData.swift`). [[1]](diffhunk://#diff-21a108da513aff3b01489b4ed1da3b1c2471a6c77a06560990da8ad8d842bcf0R26) [[2]](diffhunk://#diff-21a108da513aff3b01489b4ed1da3b1c2471a6c77a06560990da8ad8d842bcf0R51-R67)

### Codebase Simplification:
* Removed unnecessary comments from `WebExtensionMessageRouter` to clean up the code (`Sources/CardliftKit/WebExtensionMessageRouter.swift`). [[1]](diffhunk://#diff-413c1ddc936c4b7067d0c20c71771109fc7b110ddae330c2d4c89899d26cf1c1L46-L50) [[2]](diffhunk://#diff-413c1ddc936c4b7067d0c20c71771109fc7b110ddae330c2d4c89899d26cf1c1L62) [[3]](diffhunk://#diff-413c1ddc936c4b7067d0c20c71771109fc7b110ddae330c2d4c89899d26cf1c1L72)